### PR TITLE
Handle aliasPath attribute properly.

### DIFF
--- a/src/Drush/Task.php
+++ b/src/Drush/Task.php
@@ -354,7 +354,7 @@ class Task extends \Task {
     if (!empty($this->aliasPath)) {
       $option = new Option();
       $option->setName('alias-path');
-      $option->addText($this->uri);
+      $option->addText($this->aliasPath);
       $this->options[] = $option;
     }
 


### PR DESCRIPTION
Current code accidentally sets aliasPath from uri and also doesn't properly handle drush.alias-path property as result.
