### PR TITLE
Mark the Phing task working with Drush 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "phing/phing": "~2.9",
-    "drush/drush": "6.5 - 7.0"
+    "drush/drush": "6.5 - 8.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
I have upgraded Drush to v8 for my project, thus need to update composer configurations to avoid conflicts.

Tested phing-drush-task with Drush 8 in my project, and all looked fine. Please feel free to merge it.
