### PR TITLE
Mark the Phing task working with Drush 8.1 and fix reference to class \PhingFile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "phing/phing": "~2.9",
-    "drush/drush": "6.5 - 8.0"
+    "drush/drush": "6.5 - 8.1"
   },
   "autoload": {
     "psr-0": {

--- a/src/Drush/Task.php
+++ b/src/Drush/Task.php
@@ -12,6 +12,8 @@
 
 namespace Drush;
 
+use PhingFile;
+
 /**
  * Option
  * Runs the Drush commad line tool.


### PR DESCRIPTION
Two updates:
1.  Mark the Phing task working with Drush 8.1. I have been using Drush 8.1 + Phing for a while so I know this Drush task works with Drush 8.1.
2. Fix reference to class \PhingFile. This is to make following Drush task working:

`<drush command="updatedb" assume="yes" dir="/path/to/drupal" root="/path/to/drupal" uri="http://example.com" />`

Note here we use property **dir**.
