### PR TITLE
Loosen constraint on Drush version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "phing/phing": "~2.9",
-    "drush/drush": "6.5 - 8.1"
+    "drush/drush": "6.5 - 9.9"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
This change enables this project to build alongside Drush9. I see no reason why it can't work with Drush9.