### PR TITLE
Allow using Drush 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "minimum-stability": "beta",
   "require": {
     "phing/phing": "~2.9",
-    "drush/drush": "^9.0"
+    "drush/drush": "^8.1.15 || ^9.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
       "email": "pierre@buyle.org"
     }
   ],
+  "minimum-stability": "beta",
   "require": {
     "phing/phing": "~2.9",
-    "drush/drush": "6.5 - 8.1"
+    "drush/drush": "^9.0"
   },
   "autoload": {
     "psr-0": {

--- a/src/Drush/Task.php
+++ b/src/Drush/Task.php
@@ -325,13 +325,6 @@ class Task extends \Task {
       $command[] = $this->alias;
     }
 
-    if (empty($this->color)) {
-      $option = new Option();
-      $option->setName('nocolor');
-      $this->options[] = $option;
-    }
-
-
     if (!empty($this->root)) {
       $option = new Option();
       $option->setName('root');


### PR DESCRIPTION
Hi, there are just a few changes required to use this with Drush 9 -- updating the composer requirements and removing a deprecated flag.